### PR TITLE
Fix: Prevent hanging connections by adding timeouts to db.Ping()

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-29T16:05:36.988Z for PR creation at branch issue-2-6ff34342ee26 for issue https://github.com/KMTeam-LLC/Docker-DBM/issues/2

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-29T16:05:36.988Z for PR creation at branch issue-2-6ff34342ee26 for issue https://github.com/KMTeam-LLC/Docker-DBM/issues/2

--- a/docker-dbm/provisioner/mariadb.go
+++ b/docker-dbm/provisioner/mariadb.go
@@ -1,6 +1,7 @@
 package provisioner
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
@@ -27,13 +28,20 @@ func (m *MariaDBProvisioner) Name() string {
 func (m *MariaDBProvisioner) Provision(config Config) error {
 	log.Printf("[MariaDB] Connecting to server at %s:%s...", config.DBHost, config.DBPort)
 
-	// Build DSN (Data Source Name)
+	// Build DSN (Data Source Name).
+	//
+	// The "timeout" parameter caps connection establishment (dial) at the
+	// driver level as a defensive backstop alongside the PingContext timeout
+	// below, so a misconfigured network cannot stall the deployment pipeline.
+	// We deliberately do not set readTimeout/writeTimeout here, as those would
+	// also abort legitimate long-running provisioning statements.
 	dsn := fmt.Sprintf(
-		"%s:%s@tcp(%s:%s)/",
+		"%s:%s@tcp(%s:%s)/?timeout=%s",
 		config.AdminUser,
 		config.AdminPass,
 		config.DBHost,
 		config.DBPort,
+		pingTimeout,
 	)
 
 	db, err := sql.Open("mysql", dsn)
@@ -42,8 +50,11 @@ func (m *MariaDBProvisioner) Provision(config Config) error {
 	}
 	defer db.Close()
 
-	// Test the connection
-	if err := db.Ping(); err != nil {
+	// Test the connection with a strict timeout so a misconfigured network
+	// or a silently dropped connection cannot hang the deployment pipeline.
+	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
 		return fmt.Errorf("failed to ping MariaDB server: %w", err)
 	}
 	log.Println("[MariaDB] Connected successfully")

--- a/docker-dbm/provisioner/ping_timeout_test.go
+++ b/docker-dbm/provisioner/ping_timeout_test.go
@@ -1,0 +1,144 @@
+package provisioner
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// blackHoleListener starts a TCP listener that accepts connections but never
+// writes any response, simulating a misconfigured network or a firewall that
+// silently drops packets after the TCP handshake. A database driver attempting
+// its protocol handshake against such an endpoint will block until a timeout
+// fires. The listener is closed automatically when the test finishes.
+func blackHoleListener(t *testing.T) (host string, port string) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start black-hole listener: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	// Accept connections and hold them open without ever replying.
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			// Keep the connection open until the test ends; never respond.
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr)
+	return "127.0.0.1", strconv.Itoa(addr.Port)
+}
+
+// withShortPingTimeout temporarily shrinks the package-level pingTimeout so the
+// tests exercise the timeout path quickly, restoring the original afterwards.
+func withShortPingTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	original := pingTimeout
+	pingTimeout = d
+	t.Cleanup(func() { pingTimeout = original })
+}
+
+// runWithDeadline runs fn and fails the test if it does not return within the
+// given deadline, which is how we detect a hanging db.Ping call.
+func runWithDeadline(t *testing.T, deadline time.Duration, fn func() error) error {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(deadline):
+		t.Fatalf("Provision did not return within %v; the ping likely hung", deadline)
+		return nil // unreachable
+	}
+}
+
+// TestPostgresProvisionPingTimeout verifies that the PostgreSQL provisioner
+// bounds its connectivity check with a timeout instead of hanging forever when
+// the server accepts the TCP connection but never completes the handshake.
+func TestPostgresProvisionPingTimeout(t *testing.T) {
+	withShortPingTimeout(t, 500*time.Millisecond)
+	host, port := blackHoleListener(t)
+
+	prov := &PostgresProvisioner{}
+	config := Config{
+		DBType:    "postgres",
+		DBHost:    host,
+		DBPort:    port,
+		AdminUser: "admin",
+		AdminPass: "secret",
+		AppDBName: "app_db",
+		AppDBUser: "app_user",
+		AppDBPass: "app_pass",
+	}
+
+	start := time.Now()
+	err := runWithDeadline(t, 5*time.Second, func() error {
+		return prov.Provision(config)
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from ping timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to ping PostgreSQL server") {
+		t.Fatalf("expected a ping failure error, got: %v", err)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("ping took %v; expected it to be bounded by the timeout", elapsed)
+	}
+}
+
+// TestMariaDBProvisionPingTimeout verifies the same timeout behaviour for the
+// MariaDB provisioner.
+func TestMariaDBProvisionPingTimeout(t *testing.T) {
+	withShortPingTimeout(t, 500*time.Millisecond)
+	host, port := blackHoleListener(t)
+
+	prov := &MariaDBProvisioner{}
+	config := Config{
+		DBType:    "mariadb",
+		DBHost:    host,
+		DBPort:    port,
+		AdminUser: "admin",
+		AdminPass: "secret",
+		AppDBName: "app_db",
+		AppDBUser: "app_user",
+		AppDBPass: "app_pass",
+	}
+
+	start := time.Now()
+	err := runWithDeadline(t, 5*time.Second, func() error {
+		return prov.Provision(config)
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from ping timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to ping MariaDB server") {
+		t.Fatalf("expected a ping failure error, got: %v", err)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("ping took %v; expected it to be bounded by the timeout", elapsed)
+	}
+}
+
+// TestPingTimeoutDefault documents the production default of a strict 5-second
+// ping timeout as required by the issue's acceptance criteria.
+func TestPingTimeoutDefault(t *testing.T) {
+	if pingTimeout != 5*time.Second {
+		t.Fatalf("expected default pingTimeout of 5s, got %v", pingTimeout)
+	}
+}

--- a/docker-dbm/provisioner/postgres.go
+++ b/docker-dbm/provisioner/postgres.go
@@ -1,13 +1,23 @@
 package provisioner
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
+	"math"
 	"regexp"
+	"time"
 
 	_ "github.com/lib/pq"
 )
+
+// pingTimeout is the maximum duration to wait for the database connectivity
+// check (PingContext) to succeed. A strict timeout prevents db.Ping from
+// hanging indefinitely when the network is misconfigured or a firewall
+// silently drops packets, which would otherwise stall the retry loop.
+// It is a variable (rather than a constant) so tests can shorten it.
+var pingTimeout = 5 * time.Second
 
 // Pre-compiled regex patterns for efficiency
 var (
@@ -33,13 +43,25 @@ func (p *PostgresProvisioner) Name() string {
 func (p *PostgresProvisioner) Provision(config Config) error {
 	log.Printf("[PostgreSQL] Connecting to server at %s:%s...", config.DBHost, config.DBPort)
 
-	// Connect to the postgres system database
+	// Connect to the postgres system database.
+	//
+	// connect_timeout bounds the entire connection-establishment phase at the
+	// driver level. This is essential because lib/pq only honors a context
+	// during the TCP dial, not during the startup handshake; without it, a
+	// server that accepts the TCP connection but stalls the handshake (e.g. a
+	// firewall silently dropping packets) would hang despite PingContext.
+	// lib/pq accepts whole seconds only, so we round the ping timeout up.
+	connectTimeoutSecs := int(math.Ceil(pingTimeout.Seconds()))
+	if connectTimeoutSecs < 1 {
+		connectTimeoutSecs = 1
+	}
 	connStr := fmt.Sprintf(
-		"host=%s port=%s user=%s password=%s dbname=postgres sslmode=disable",
+		"host=%s port=%s user=%s password=%s dbname=postgres sslmode=disable connect_timeout=%d",
 		config.DBHost,
 		config.DBPort,
 		config.AdminUser,
 		config.AdminPass,
+		connectTimeoutSecs,
 	)
 
 	db, err := sql.Open("postgres", connStr)
@@ -48,8 +70,11 @@ func (p *PostgresProvisioner) Provision(config Config) error {
 	}
 	defer db.Close()
 
-	// Test the connection
-	if err := db.Ping(); err != nil {
+	// Test the connection with a strict timeout so a misconfigured network
+	// or a silently dropped connection cannot hang the deployment pipeline.
+	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
 		return fmt.Errorf("failed to ping PostgreSQL server: %w", err)
 	}
 	log.Println("[PostgreSQL] Connected successfully")


### PR DESCRIPTION
## Summary

Prevents the deployment pipeline from stalling when `db.Ping()` hangs indefinitely against a misconfigured network or a firewall that silently drops packets.

Fixes KMTeam-LLC/Docker-DBM#2

## Changes

- **`provisioner/postgres.go`** and **`provisioner/mariadb.go`**: replaced the unbounded `db.Ping()` with `db.PingContext(ctx)`, where `ctx` comes from `context.WithTimeout(context.Background(), pingTimeout)` (default **5s**), with `defer cancel()` to avoid context leaks. Imports `context`/`time` as required.
- **Root-cause backstop (PostgreSQL):** `lib/pq` only honors a context during the TCP *dial*, **not** during the startup *handshake*. So `PingContext` alone still hangs against a server that accepts the TCP connection but stalls the handshake. Added `connect_timeout` to the Postgres connection string — it sets a socket deadline covering handshake I/O and is cleared by the driver after startup, so it does not affect later queries.
- **Defensive backstop (MariaDB):** added a dial `timeout` to the DSN. `go-sql-driver/mysql` already honors the context fully, so this is purely defensive. `readTimeout`/`writeTimeout` were intentionally *not* set, as they would also abort legitimate long-running provisioning statements.
- The 5s timeout is a package-level `var pingTimeout` so tests can shorten it; `connect_timeout` (whole seconds only) is derived from it via `ceil`, floored at 1s.

## How to reproduce / test

`provisioner/ping_timeout_test.go` adds a **black-hole TCP listener** that accepts the connection but never replies — simulating a silent packet drop after the handshake. Each provisioner test asserts `Provision` returns *bounded by the timeout* (with a 5s deadline guard) instead of hanging, and that the error is the expected ping failure. Before the fix the PostgreSQL case hangs (verified: it ran to the 5s deadline without `connect_timeout`).

```
cd docker-dbm && go test ./...
```

```
ok  github.com/KMTeam-LLC/Docker-DBM/docker-dbm/provisioner
```

Also removed the auto-generated `.gitkeep` placeholder that was only used to open this PR.
