### PR TITLE
Optimize: Remove unnecessary `FLUSH PRIVILEGES` from MariaDB provisioner

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-29T16:11:16.654Z for PR creation at branch issue-3-c00432758882 for issue https://github.com/KMTeam-LLC/Docker-DBM/issues/3

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-29T16:11:16.654Z for PR creation at branch issue-3-c00432758882 for issue https://github.com/KMTeam-LLC/Docker-DBM/issues/3

--- a/docker-dbm/provisioner/mariadb.go
+++ b/docker-dbm/provisioner/mariadb.go
@@ -48,6 +48,15 @@ func (m *MariaDBProvisioner) Provision(config Config) error {
 	}
 	log.Println("[MariaDB] Connected successfully")
 
+	return m.provision(db, config)
+}
+
+// provision performs the actual database and user provisioning against an
+// already-established connection. It is separated from Provision so the
+// provisioning logic can be exercised with a mocked database in tests.
+func (m *MariaDBProvisioner) provision(db *sql.DB, config Config) error {
+	var err error
+
 	// Validate identifiers to prevent SQL injection
 	if !isValidMariaDBIdentifier(config.AppDBName) {
 		return fmt.Errorf("invalid database name: %s (must contain only alphanumeric characters and underscores)", config.AppDBName)
@@ -134,12 +143,12 @@ func (m *MariaDBProvisioner) Provision(config Config) error {
 	}
 	log.Printf("[MariaDB] Granted ALL PRIVILEGES on '%s.*' to '%s'", config.AppDBName, config.AppDBUser)
 
-	// Flush privileges to ensure changes take effect
-	_, err = db.Exec("FLUSH PRIVILEGES")
-	if err != nil {
-		log.Printf("[MariaDB] WARNING: Failed to flush privileges: %v", err)
-		// Continue anyway as the grants should still work
-	}
+	// NOTE: No FLUSH PRIVILEGES is needed here. In MariaDB/MySQL, that statement is
+	// only required when the grant tables are modified directly via INSERT/UPDATE/DELETE.
+	// Account management statements (CREATE USER, GRANT) automatically reload the
+	// in-memory grant tables, so privileges take effect immediately. Skipping the
+	// statement also avoids a needless round-trip and a failure when the admin user
+	// lacks the global RELOAD privilege.
 
 	log.Println("[MariaDB] Provisioning completed successfully!")
 	log.Printf("[MariaDB] Database: %s | User: %s | Host: %s:%s",

--- a/docker-dbm/provisioner/mariadb_test.go
+++ b/docker-dbm/provisioner/mariadb_test.go
@@ -1,0 +1,167 @@
+package provisioner
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// The tests below exercise MariaDBProvisioner.provision against a custom
+// recording database driver. Unlike a mock that only checks a fixed set of
+// expectations, this driver captures EVERY statement the provisioner sends,
+// which lets us assert that no FLUSH PRIVILEGES statement is ever issued
+// (the subject of issue #3).
+
+// recorder collects every statement executed through the fake driver.
+type recorder struct {
+	mu    sync.Mutex
+	stmts []string
+}
+
+func (r *recorder) add(query string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stmts = append(r.stmts, query)
+}
+
+func (r *recorder) statements() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.stmts))
+	copy(out, r.stmts)
+	return out
+}
+
+// activeRecorder is the recorder used by connections opened through the fake
+// driver. Tests set it (guarded by registerOnce) before opening a connection.
+var (
+	activeRecorder *recorder
+	registerOnce   sync.Once
+)
+
+const fakeDriverName = "docker-dbm-recorder"
+
+type fakeDriver struct{}
+
+func (fakeDriver) Open(string) (driver.Conn, error) {
+	return &fakeConn{rec: activeRecorder}, nil
+}
+
+type fakeConn struct{ rec *recorder }
+
+// Prepare is required by driver.Conn but is unused: implementing the
+// *Context interfaces makes database/sql bypass the prepared-statement path.
+func (c *fakeConn) Prepare(string) (driver.Stmt, error) { return nil, driver.ErrSkip }
+func (c *fakeConn) Close() error                        { return nil }
+func (c *fakeConn) Begin() (driver.Tx, error)           { return nil, driver.ErrSkip }
+
+func (c *fakeConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	c.rec.add(query)
+	return driver.RowsAffected(1), nil
+}
+
+func (c *fakeConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	c.rec.add(query)
+	// All queries in the provisioner are COUNT(*) existence checks; return 0
+	// so the provisioner proceeds as if nothing exists yet.
+	return &fakeRows{cols: []string{"count"}, vals: [][]driver.Value{{int64(0)}}}, nil
+}
+
+type fakeRows struct {
+	cols []string
+	vals [][]driver.Value
+	pos  int
+}
+
+func (r *fakeRows) Columns() []string { return r.cols }
+func (r *fakeRows) Close() error      { return nil }
+func (r *fakeRows) Next(dest []driver.Value) error {
+	if r.pos >= len(r.vals) {
+		return io.EOF
+	}
+	copy(dest, r.vals[r.pos])
+	r.pos++
+	return nil
+}
+
+// newRecordingDB opens a *sql.DB backed by the recording driver and returns it
+// together with the recorder capturing its statements.
+func newRecordingDB(t *testing.T) (*sql.DB, *recorder) {
+	t.Helper()
+	registerOnce.Do(func() {
+		sql.Register(fakeDriverName, fakeDriver{})
+	})
+	rec := &recorder{}
+	activeRecorder = rec
+	db, err := sql.Open(fakeDriverName, "")
+	if err != nil {
+		t.Fatalf("failed to open recording db: %v", err)
+	}
+	return db, rec
+}
+
+func testConfig() Config {
+	return Config{
+		DBType:    "mariadb",
+		DBHost:    "localhost",
+		DBPort:    "3306",
+		AdminUser: "admin",
+		AdminPass: "adminpass",
+		AppDBName: "appdb",
+		AppDBUser: "appuser",
+		AppDBPass: "apppass",
+	}
+}
+
+// TestProvisionNeverFlushesPrivileges is the regression test for issue #3:
+// the provisioner must NOT issue a FLUSH PRIVILEGES statement, since
+// CREATE USER / GRANT update the in-memory grant tables automatically.
+func TestProvisionNeverFlushesPrivileges(t *testing.T) {
+	db, rec := newRecordingDB(t)
+	defer db.Close()
+
+	m := &MariaDBProvisioner{}
+	if err := m.provision(db, testConfig()); err != nil {
+		t.Fatalf("provision returned unexpected error: %v", err)
+	}
+
+	for _, stmt := range rec.statements() {
+		if strings.Contains(strings.ToUpper(stmt), "FLUSH PRIVILEGES") {
+			t.Errorf("provision executed a forbidden FLUSH PRIVILEGES statement: %q", stmt)
+		}
+	}
+}
+
+// TestProvisionExecutesExpectedStatements verifies that, after removing the
+// flush, the provisioner still performs the expected work: existence checks,
+// database creation, user creation, and a database-scoped grant.
+func TestProvisionExecutesExpectedStatements(t *testing.T) {
+	db, rec := newRecordingDB(t)
+	defer db.Close()
+
+	m := &MariaDBProvisioner{}
+	if err := m.provision(db, testConfig()); err != nil {
+		t.Fatalf("provision returned unexpected error: %v", err)
+	}
+
+	stmts := rec.statements()
+	requireStatement(t, stmts, "INFORMATION_SCHEMA.SCHEMATA")
+	requireStatement(t, stmts, "FROM mysql.user")
+	requireStatement(t, stmts, "CREATE DATABASE `appdb`")
+	requireStatement(t, stmts, "CREATE USER `appuser`@'%'")
+	requireStatement(t, stmts, "GRANT ALL PRIVILEGES ON `appdb`.* TO `appuser`@'%'")
+}
+
+func requireStatement(t *testing.T, stmts []string, substr string) {
+	t.Helper()
+	for _, s := range stmts {
+		if strings.Contains(s, substr) {
+			return
+		}
+	}
+	t.Errorf("expected a statement containing %q, executed statements were: %v", substr, stmts)
+}


### PR DESCRIPTION
## Summary

Removes the `FLUSH PRIVILEGES` statement from the MariaDB provisioner.

In MariaDB/MySQL, `FLUSH PRIVILEGES` is only required when the grant tables are modified **directly** via `INSERT`/`UPDATE`/`DELETE`. Docker-DBM exclusively uses account-management statements (`CREATE USER`, `GRANT`), which automatically reload the in-memory grant tables, so privileges take effect immediately. Removing the call:

- saves a network round-trip, and
- avoids a failure when the admin user lacks the global `RELOAD` privilege.

Fixes #3

## Changes

- `provisioner/mariadb.go`
  - Removed the `db.Exec("FLUSH PRIVILEGES")` call and its error-handling block, replacing it with a comment explaining why no flush is needed.
  - Extracted the post-connection logic into an internal `provision(*sql.DB, Config)` helper so the provisioning flow is unit-testable without a live database. `Provision` still owns connection setup/ping; behavior is otherwise unchanged.
- `provisioner/mariadb_test.go` (new)
  - Regression tests built on a small recording `database/sql/driver` that captures **every** statement the provisioner issues.

## How the fix is verified

- `TestProvisionNeverFlushesPrivileges` — asserts no `FLUSH PRIVILEGES` statement is ever executed.
- `TestProvisionExecutesExpectedStatements` — asserts the existence checks, `CREATE DATABASE`, `CREATE USER`, and the database-scoped `GRANT ALL PRIVILEGES ON \`appdb\`.*` still run, confirming privileges are still applied correctly after the change.

The regression test was sanity-checked by temporarily re-adding the flush: the test fails as expected with the flush present and passes once it is removed.

```
$ go test ./provisioner/ -v
=== RUN   TestProvisionNeverFlushesPrivileges
--- PASS: TestProvisionNeverFlushesPrivileges (0.00s)
=== RUN   TestProvisionExecutesExpectedStatements
--- PASS: TestProvisionExecutesExpectedStatements (0.00s)
PASS
ok      github.com/KMTeam-LLC/Docker-DBM/docker-dbm/provisioner
```

No new runtime dependencies are introduced (the recording driver lives entirely in the test file).