### PR TITLE
Add complete rollback blocks for failed REVOKE/GRANT operations in PostgreSQL

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-29T16:14:10.780Z for PR creation at branch issue-4-16248e15ec8f for issue https://github.com/KMTeam-LLC/Docker-DBM/issues/4

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-29T16:14:10.780Z for PR creation at branch issue-4-16248e15ec8f for issue https://github.com/KMTeam-LLC/Docker-DBM/issues/4

--- a/docker-dbm/go.mod
+++ b/docker-dbm/go.mod
@@ -3,6 +3,7 @@ module github.com/KMTeam-LLC/Docker-DBM/docker-dbm
 go 1.24.13
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/lib/pq v1.12.0
 )

--- a/docker-dbm/go.sum
+++ b/docker-dbm/go.sum
@@ -1,6 +1,9 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/lib/pq v1.12.0 h1:mC1zeiNamwKBecjHarAr26c/+d8V5w/u4J0I/yASbJo=
 github.com/lib/pq v1.12.0/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=

--- a/docker-dbm/provisioner/postgres.go
+++ b/docker-dbm/provisioner/postgres.go
@@ -127,6 +127,8 @@ func (p *PostgresProvisioner) Provision(config Config) error {
 	_, err = db.Exec(revokeQuery)
 	if err != nil {
 		log.Printf("[PostgreSQL] WARNING: Failed to revoke public access: %v", err)
+		// Cleanup: drop the database and user to avoid leaving orphaned resources
+		rollbackPostgres(db, config.AppDBName, config.AppDBUser)
 		// This is a security-critical operation, so we treat it as an error
 		return fmt.Errorf("failed to revoke public access: %w", err)
 	}
@@ -140,6 +142,8 @@ func (p *PostgresProvisioner) Provision(config Config) error {
 	)
 	_, err = db.Exec(grantQuery)
 	if err != nil {
+		// Cleanup: drop the database and user to avoid leaving orphaned resources
+		rollbackPostgres(db, config.AppDBName, config.AppDBUser)
 		return fmt.Errorf("failed to grant privileges: %w", err)
 	}
 	log.Printf("[PostgreSQL] Granted all privileges on '%s' to '%s'", config.AppDBName, config.AppDBUser)
@@ -149,6 +153,24 @@ func (p *PostgresProvisioner) Provision(config Config) error {
 		config.AppDBName, config.AppDBUser, config.DBHost, config.DBPort)
 
 	return nil
+}
+
+// rollbackPostgres drops the newly created database and user to avoid leaving
+// orphaned resources when provisioning fails after both have been created.
+// Identifiers are safely escaped using quoteIdentifier(). Cleanup errors are
+// logged but not returned, since the original provisioning error takes priority.
+func rollbackPostgres(db *sql.DB, dbName, dbUser string) {
+	log.Printf("[PostgreSQL] Rolling back: dropping database '%s' and user '%s'...", dbName, dbUser)
+
+	dropDBQuery := fmt.Sprintf("DROP DATABASE IF EXISTS %s", quoteIdentifier(dbName))
+	if _, err := db.Exec(dropDBQuery); err != nil {
+		log.Printf("[PostgreSQL] WARNING: Failed to drop database '%s' during rollback: %v", dbName, err)
+	}
+
+	dropUserQuery := fmt.Sprintf("DROP USER IF EXISTS %s", quoteIdentifier(dbUser))
+	if _, err := db.Exec(dropUserQuery); err != nil {
+		log.Printf("[PostgreSQL] WARNING: Failed to drop user '%s' during rollback: %v", dbUser, err)
+	}
 }
 
 // quoteIdentifier properly quotes a PostgreSQL identifier to prevent SQL injection.

--- a/docker-dbm/provisioner/postgres_test.go
+++ b/docker-dbm/provisioner/postgres_test.go
@@ -1,0 +1,75 @@
+package provisioner
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// TestRollbackPostgres verifies that rollbackPostgres issues both a
+// DROP DATABASE and a DROP USER statement so that no orphaned resources are
+// left behind when provisioning fails after the database and user are created.
+func TestRollbackPostgres(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta(`DROP DATABASE IF EXISTS "appdb"`)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`DROP USER IF EXISTS "appuser"`)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	rollbackPostgres(db, "appdb", "appuser")
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("rollback did not issue the expected statements: %v", err)
+	}
+}
+
+// TestRollbackPostgresQuotesIdentifiers ensures that rollback identifiers are
+// safely escaped via quoteIdentifier(), preventing SQL injection through
+// malicious database or user names.
+func TestRollbackPostgresQuotesIdentifiers(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	// A name containing a double quote must be doubled when escaped.
+	mock.ExpectExec(regexp.QuoteMeta(`DROP DATABASE IF EXISTS "ev""il"`)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(regexp.QuoteMeta(`DROP USER IF EXISTS "ro""ot"`)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	rollbackPostgres(db, `ev"il`, `ro"ot`)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("rollback did not escape identifiers as expected: %v", err)
+	}
+}
+
+// TestRollbackPostgresContinuesOnDropDatabaseError verifies that a failure to
+// drop the database does not prevent the user from also being dropped.
+func TestRollbackPostgresContinuesOnDropDatabaseError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(regexp.QuoteMeta(`DROP DATABASE IF EXISTS "appdb"`)).
+		WillReturnError(errors.New("database in use"))
+	mock.ExpectExec(regexp.QuoteMeta(`DROP USER IF EXISTS "appuser"`)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	rollbackPostgres(db, "appdb", "appuser")
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("rollback did not attempt to drop the user after a database drop failure: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes KMTeam-LLC/Docker-DBM#4.

In `provisioner/postgres.go`, provisioning created the user and database, then ran `REVOKE ALL ON DATABASE ... FROM PUBLIC` and `GRANT ALL PRIVILEGES ON DATABASE ...`. If either of those statements failed, the function returned an error but **left behind an orphaned database and user** — only the earlier `CREATE DATABASE` failure path performed cleanup.

This PR adds complete rollback for every failure point after both resources exist, matching the existing cleanup style in `mariadb.go`.

## Changes

- Added a `rollbackPostgres(db, dbName, dbUser)` helper that drops both the database and the user using `DROP DATABASE IF EXISTS ...` and `DROP USER IF EXISTS ...`, with identifiers safely escaped via the existing `quoteIdentifier()` helper. Cleanup errors are logged (not returned) so the original provisioning error is preserved.
- Invoke the helper in the **REVOKE** error path.
- Invoke the helper in the **GRANT** error path.
- Added unit tests with `go-sqlmock` covering the rollback statements, identifier escaping, and that the user drop is still attempted when the database drop fails.

## Acceptance Criteria

- [x] Locate the `REVOKE ALL ON DATABASE` error handling block in `provisioner/postgres.go`.
- [x] Add rollback queries (`DROP DATABASE IF EXISTS...` and `DROP USER IF EXISTS...`) to execute if the `REVOKE` fails.
- [x] Locate the `GRANT ALL PRIVILEGES` error handling block in `provisioner/postgres.go`.
- [x] Add the same rollback queries to execute if the `GRANT` fails.
- [x] Ensure all rollback identifiers are safely escaped using the existing `quoteIdentifier()` helper.

## Testing

```
$ go build ./... && go vet ./... && go test ./...
ok  	github.com/KMTeam-LLC/Docker-DBM/docker-dbm/provisioner
```
